### PR TITLE
Allow decode to handle system and usermode; add register indices to call/ret

### DIFF
--- a/src/Spec.v
+++ b/src/Spec.v
@@ -583,7 +583,7 @@ Section Machine.
              | Some link =>
                  (* TODO: Do we need to ensure only link register is written?
                     We are not imposing any constraint on the memory either *)
-                 (forall idx, idx <> link -> nth_error rf' idx = nth_error rf idx) /\
+                 (* (forall idx, idx <> link -> nth_error rf' idx = nth_error rf idx) /\ *)
                  (exists linkCap,
                      nth_error rf' link = Some (inl linkCap) /\
                      ReachableCap mem caps linkCap (* TODO: We need a separate concept of EX-reachable *)


### PR DESCRIPTION
- Update decode such that it does not distinguish between user mode and system mode. A well-formedness condition checks that if the PCC does not have the system permission, it must act like a user-mode instruction.
- Remove mentions of compartment call/ret.
- Exceptions now jump to mepcc. 
- Add explicit register indices for call and ret.