### PR TITLE
Configure an initial machine with import/export tables, threads, etc

### DIFF
--- a/src/Properties.v
+++ b/src/Properties.v
@@ -469,8 +469,18 @@ Module Configuration.
 End Configuration.
 
 
+(* Shared buffer abstraction.
+   If a compartment:
+   - only passes arguments without Cap permission
+   - and is only passed arguments without Cap permission,
+   then no other compartment should 
+ *)
 
-
+(* If a compartment:
+   - sanitizes its arguments such that LG is unset
+   - does not return caps into anything passed by a caller
+   - does not write caps to memory regions that are currently live...  
+ *)
 
 
 (* If a (malicious) compartment is not transitively-reachable from a

--- a/src/Properties.v
+++ b/src/Properties.v
@@ -429,6 +429,27 @@ Module CompartmentIsolation.
              AddrInCompartment config idx1 addr ->
              ReachableRWXAddr machine.(machine_memory) (capsOfThread thread) addr ->
              False).
+
+      Definition Invariant (st: State) : Prop.
+      Admitted.
+
+      Lemma InvariantStep (s: State) :
+        forall t,
+        Invariant s ->
+        MachineStep s t ->
+        Invariant t.
+      Admitted.
+
+      Lemma InvariantUse (s: State) :
+        Invariant s ->
+        PCompartmentIsolation s.
+      Admitted.
+
+      Lemma InvariantInitial :
+        forall initial_machine,
+        ValidInitialState config initial_machine ->
+        Invariant (initial_machine, []).
+      Admitted.
     End WithConfig.
 
     Theorem CompartmentIsolation :
@@ -436,7 +457,13 @@ Module CompartmentIsolation.
         WFConfig config ->
         ValidInitialState config initial_machine ->
         Combinators.always MachineStep (PCompartmentIsolation config) (initial_machine, []).
-    Admitted.
+    Proof.
+      intros * hwf_config hinit_ok.
+      econstructor.
+      - eapply InvariantInitial; eauto.
+      - eapply InvariantStep; eauto.
+      - eapply InvariantUse; eauto.
+    Qed.
 
   End WithContext.
 End CompartmentIsolation.

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -536,6 +536,7 @@ Section Machine.
           | Ok (pcc', rf', ints') =>
             let caps := pcc :: capsOfRf rf in
             In Perm.Exec pcc.(capPerms) /\
+            isSealed pcc = false /\
             (exists src_cap,
                nth_error rf src = Some (inl src_cap) /\
                In Perm.Exec src_cap.(capPerms) /\
@@ -552,7 +553,7 @@ Section Machine.
                  (forall idx, idx <> link -> nth_error rf' idx = nth_error rf idx)
                  /\ (exists linkCap,
                         nth_error rf' link = Some (inl linkCap)
-                        /\ RestrictUnsealed pcc linkCap (* TODO: Check correctness *)
+                        /\ RestrictUnsealed pcc (setCapSealed linkCap None) (* TODO: Check correctness *)
                         /\ linkCap.(capSealed) = Some (inl (if ints
                                                             then RetEnableInterrupt
                                                             else RetDisableInterrupt))

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -254,11 +254,13 @@ Section Machine.
       (* Cap z is the sealed version of cap y using a key in x *)
       Definition Seal : Prop :=
         exists k, In k x.(capSealingKeys) /\
+             x.(capSealed) = None /\
              y.(capSealed) = None /\
              z = setCapSealed y (Some (inr k)).
 
       Definition Unseal : Prop :=
-        exists k, In k x.(capSealingKeys) /\
+        exists k, In k x.(capUnsealingKeys) /\
+             x.(capSealed) = None /\
              y.(capSealed) = Some (inr k) /\
              z = setCapSealed y None.
     End CapStep.

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -292,7 +292,8 @@ Section Machine.
           /\ Subset (seq a sz) auth.(capAddrs).
 
         Definition StPermForCap (auth: Cap) (capa: CapAddr) :=
-          StPermForAddr auth (fromCapAddr capa) ISA_CAPSIZE_BYTES.
+          StPermForAddr auth (fromCapAddr capa) ISA_CAPSIZE_BYTES /\
+          In Perm.Cap auth.(capPerms).
 
         Definition ValidMemCapUpdate :=
           forall capa stDataCap, readCap mem capa <> readCap mem' capa ->

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -53,9 +53,8 @@ Section WithContext.
 
     (* Addresses reachable with read, write, or execute permission. *)
     Definition ReachableRWXAddr (mem: FullMemory) (caps: list Cap) (a: Addr) :=
-      ReachableReadAddr mem caps a \/
-      ReachableWriteAddr mem caps a \/
-      ReachableExecAddr mem caps a.
+      exists p cs cbs,
+        ReachableAddr mem caps a 1 p cs cbs /\ (In Perm.Load p \/ In Perm.Store p \/ In Perm.Exec p).
 
     Definition RWAddressesDisjoint (mem: FullMemory) (c1 c2: list Cap) : Prop :=
       forall a,

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -41,10 +41,21 @@ Section WithContext.
       exists p cs cbs ,
         ReachableAddr mem caps a 1 p cs cbs /\ (In Perm.Store p).
 
+    (* Addresses reachable with execute permission. *)
+    Definition ReachableExecAddr (mem: FullMemory) (caps: list Cap) (a: Addr) :=
+      exists p cs cbs ,
+        ReachableAddr mem caps a 1 p cs cbs /\ (In Perm.Exec p).
+
     (* Addresses reachable with read or write permission. *)
     Definition ReachableRWAddr (mem: FullMemory) (caps: list Cap) (a: Addr) :=
       ReachableReadAddr mem caps a \/
-      ReachableWriteAddr mem caps a.
+        ReachableWriteAddr mem caps a.
+
+    (* Addresses reachable with read, write, or execute permission. *)
+    Definition ReachableRWXAddr (mem: FullMemory) (caps: list Cap) (a: Addr) :=
+      ReachableReadAddr mem caps a \/
+      ReachableWriteAddr mem caps a \/
+      ReachableExecAddr mem caps a.
 
     Definition RWAddressesDisjoint (mem: FullMemory) (c1 c2: list Cap) : Prop :=
       forall a,

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -390,7 +390,7 @@ Section WithContext.
         StPermForCap mem caps' addr capa.
     Proof.
       cbv[StPermForCap].
-      intros. destruct_products.
+      intros. destruct_products. split; auto.
       eapply StPermForAddrSubset; eauto.
     Qed.
     Lemma ValidMemTagRemovalSubset:

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -181,10 +181,10 @@ Section WithContext.
       cbv[setCapSealed]. destruct c; intros; cbn in *; subst; auto.
     Qed.
     Lemma setCapSealed_inv:
-      forall (x: Cap) y z,
-        setCapSealed (setCapSealed x y) z = setCapSealed x z.
+      forall (x: Cap) (optSeal optSeal': option SealT),
+        setCapSealed (setCapSealed x optSeal) optSeal' = setCapSealed x optSeal'.
     Proof.
-      cbv[setCapSealed]. reflexivity.
+      reflexivity.
     Qed.
 
   End CapStepLemmas.

--- a/src/Tactics.v
+++ b/src/Tactics.v
@@ -1,5 +1,4 @@
-From Stdlib Require Import List Lia Bool Nat NArith.
-
+From Stdlib Require Import String List Lia Bool Nat NArith.
 
 Tactic Notation "learn_hyp" constr(p) "as" ident(H') :=
   let P := type of p in
@@ -133,6 +132,7 @@ Tactic Notation "split_and" :=
   | |- _/\ _ => split
   end.
 Tactic Notation "split_and" "?" := repeat split_and.
+Ltac split_ands := repeat split_and.
 Tactic Notation "split_and" "!" := hnf; split_and; split_and?.
 Tactic Notation "destruct_or" "?" ident(H) :=
   repeat match type of H with
@@ -162,4 +162,32 @@ Ltac assert_pre_and_specialize H :=
 Ltac rewrite_solve :=
   match goal with
   | [ H: _ |- _ ] => solve[rewrite H; try congruence; auto]
+  end.
+Ltac simplify_tuples :=
+  repeat match goal with
+  | [ H: (_,_) = (_,_) |- _ ] =>
+    apply simple_tuple_inversion in H; destruct H
+  end.
+
+Ltac simplify_tupless := simplify_tuples; subst.
+
+Ltac bash_destruct H :=
+  repeat destruct_matches_in_hyp H; simpl in H; simplify_tupless; try congruence.
+
+Ltac destruct_and_save H :=
+  let H' := fresh H in
+  pose proof H as H';
+  destruct H'.
+
+Inductive MARK : string -> Type :=
+| MkMark : forall s, MARK s.
+
+Tactic Notation "mark" constr(p) :=
+  let H := fresh "Mark" in
+  learn_hyp p as H.
+
+Tactic Notation "assert_fresh" constr(P) "as" ident(H') :=
+  match goal with
+  | H : P |- _ => fail 1
+  | _ => assert P as H'
   end.

--- a/src/Tactics.v
+++ b/src/Tactics.v
@@ -1,5 +1,15 @@
 From Stdlib Require Import List Lia Bool Nat NArith.
 
+
+Tactic Notation "learn_hyp" constr(p) "as" ident(H') :=
+  let P := type of p in
+  match goal with
+  | H : P |- _ => fail 1
+  | _ => pose proof p as H'
+  end.
+Tactic Notation "learn_hyp" constr(p) :=
+  let H := fresh in learn_hyp p as H.
+
 Lemma simple_tuple_inversion:
   forall {A} {B} (a: A) (b: B) x y,
   (a,b) = (x,y) ->

--- a/src/Utils.v
+++ b/src/Utils.v
@@ -251,8 +251,15 @@ Qed.
 Ltac saturate_list:=
   repeat match goal with
   | H: nth_error ?xs ?idx = Some _ |- _ =>
-      learn_hyp (nth_error_Some' _ _ _ H)
-  end.                 
+      let H' := fresh H "len" in 
+      learn_hyp (nth_error_Some' _ _ _ H) as H'
+  | H: nth_error ?xs ?idx = Some _ |- _ =>
+      let H' := fresh H "In" in 
+      learn_hyp (nth_error_In _ _ H) as H'
+  | H: Forall2 _ _ _ |- _ =>
+      let H' := fresh H "len" in 
+      learn_hyp (Forall2_length H) as H'
+    end.
 
 
 Fixpoint listSumToInl [A B: Type] (l: list (A+B)) : list A :=

--- a/src/Utils.v
+++ b/src/Utils.v
@@ -94,6 +94,10 @@ Section Option.
   Proof.
     destruct x; congruence.
   Qed.
+
+  Definition from_option {A B} (f : A -> B) (y : B) (mx : option A) : B :=
+    match mx with None => y | Some x => f x end.
+
 End Option.
 
 Ltac option_simpl :=
@@ -281,6 +285,36 @@ Fixpoint listSumToInl [A B: Type] (l: list (A+B)) : list A :=
                | _ => listSumToInl xs
                end
   end.
+Lemma In_listSumToInl:
+  forall A B (xs: list (A+B)) x,
+  In (inl x) xs ->
+  In x (listSumToInl xs).
+Proof.
+  induction xs; cbn; auto.
+  intros * H. inv H; subst; auto.
+  - constructor. auto.
+  - apply IHxs in H0. case_match; [right | ]; auto.
+Qed.
+Lemma listSumToInl_In:
+  forall A B (xs: list (A+B)) x,
+  In x (listSumToInl xs) ->
+  In (inl x) xs.
+Proof.
+  induction xs; cbn; auto.
+  intros. case_match; subst.
+  - inv H; auto.
+  - apply IHxs in H. auto.
+Qed.
+
+Lemma listSumToInl_iff:
+  forall A B (xs: list (A+B)) x,
+  In x (listSumToInl xs) <->
+  In (inl x) xs.
+Proof.
+  split.
+  - apply listSumToInl_In.
+  - apply In_listSumToInl.
+Qed.
 
 Theorem seqInBounds n: forall b v,
     b <= v < b + n -> In v (seq b n).

--- a/src/Utils.v
+++ b/src/Utils.v
@@ -241,6 +241,20 @@ Section ListUpdate.
   Qed.
 End ListUpdate.
 
+Lemma nth_error_Some' :
+  forall [A: Type] (l: list A) (n: nat) (a: A),
+    nth_error l n = Some a ->
+    n < length l.
+Proof.
+  intros. eapply nth_error_Some. by eapply Some_not_None.
+Qed.
+Ltac saturate_list:=
+  repeat match goal with
+  | H: nth_error ?xs ?idx = Some _ |- _ =>
+      learn_hyp (nth_error_Some' _ _ _ H)
+  end.                 
+
+
 Fixpoint listSumToInl [A B: Type] (l: list (A+B)) : list A :=
   match l with
   | nil => nil
@@ -259,3 +273,10 @@ Proof.
     apply IHn.
     lia.
 Qed.
+
+Ltac simplify_nat :=
+  repeat match goal with
+  | H: _ <? _ = true |- _ => rewrite PeanoNat.Nat.ltb_lt in H
+  | H: _ <? _ = false |- _ => rewrite PeanoNat.Nat.ltb_nlt in H
+  | _ => lia                                                                       
+  end.

--- a/src/Utils.v
+++ b/src/Utils.v
@@ -260,6 +260,17 @@ Ltac saturate_list:=
       let H' := fresh H "len" in 
       learn_hyp (Forall2_length H) as H'
     end.
+Ltac unsafe_saturate_list :=
+  saturate_list;
+  repeat match goal with
+  | H: In ?xs ?x |- _ =>
+      lazymatch goal with
+      | H': nth_error xs _ = Some x |- _ => fail 1
+      | |- _ =>
+          let H' := fresh H "nth_error" in
+          learn_hyp (In_nth_error _ _ H) as H'
+      end
+  end.
 
 
 Fixpoint listSumToInl [A B: Type] (l: list (A+B)) : list A :=


### PR DESCRIPTION
Additions:

- Import tables, export tables, and libraries in the initial machine configuration.
- Initial properties about capabilities a compartment and stack initially have access to, in terms of PCC/CGP/CSP/import tables.
- A notion of the provenance of an address (stack or compartment) and  a proof of uniqueness.
- For validation purposes, prove that mutually disjoint compartments are initially isolated (in terms of RWX addresses, sentries, and sealed data caps).
- Helper tactics and lemmas about reachable addresses, `Restrict`, etc.

Spec bug fixes:

- Enforce that the authorization cap has `Perm.Cap` when storing a cap.
- Fix property on `linkCap` in `WfCallSentryInst` (permissions should be reduced before sealing, else no cap satisfies `RestrictUnsealed` property).
- Ensure authorization cap in `Seal` and `Unseal` is not sealed. 