### PR TITLE
Initial switcher specification

### DIFF
--- a/src/Properties.v
+++ b/src/Properties.v
@@ -1811,9 +1811,10 @@ Module CompartmentIsolationValidation.
             Some (Build_Thread
                     (Build_UserThreadState
                        (thread_rf (thread_userState thread))
-                       (thread_mepcc (thread_systemState thread)))
+                       (thread_mtcc (thread_systemState thread)))
                     (Build_SystemThreadState
                        (thread_pcc (thread_userState thread))
+                       (thread_mtcc (thread_systemState thread))
                        exn 
                        (thread_trustedStack (thread_systemState thread))
                        status 
@@ -1833,7 +1834,7 @@ Module CompartmentIsolationValidation.
           { exfalso.
             eapply ThreadInUserCompartmentDoesNotHaveSystemPerm; eauto.
             cbv[ThreadHasSystemPerm]; cbn.
-            erewrite MEPCC_ok by (eapply HUserMode; eauto).
+            erewrite MTCC_ok by (eapply HUserMode; eauto).
             cbn. eauto.
           }
           { rewrite hsame in * by lia.
@@ -1850,7 +1851,7 @@ Module CompartmentIsolationValidation.
           destruct (PeanoNat.Nat.eq_dec (machine_curThreadId m) n); subst; option_simpl; cbn.
           { exfalso. apply ht_userMode.
             cbn.
-            erewrite MEPCC_ok by (eapply HUserMode; eauto).
+            erewrite MTCC_ok by (eapply HUserMode; eauto).
             cbn. eauto.
           }
           { rewrite hsame in * by lia.
@@ -2243,7 +2244,7 @@ Module CompartmentIsolationValidation.
           destruct hvalid. destruct_products. unfold hd_error in *.
           simpl_match; option_simpl.
           match goal with
-          | H: ValidTrustedStackFrame _ _ _ _ _ _ |- _ => destruct H
+          | H: ValidTrustedStackFrame _ _ _ _ _ |- _ => destruct H
           end; destruct_products; option_simpl; simplify_tupless; eauto.
         Qed.
 

--- a/src/Properties.v
+++ b/src/Properties.v
@@ -670,8 +670,10 @@ End Configuration.
    We obtain a notion of atomicity by enforcing that the switcher
    operates only on register file, thread-local stack memory regions,
    and read-only global memory. This ensures that the switcher behaves
-   as if it were atomic, with straightforward postconditions that are
-   a function only of the state at time of call/ret.
+   as if it were atomic, as the effect of its actions on memory are
+   disjoint from other threads' effects, and maintains straightforward
+   postconditions that are a function only of the state at time of
+   call/ret.
 
    Notes:
    - We have specified the behavior of the interrupt handler as
@@ -1561,14 +1563,14 @@ Module SwitcherProperty.
 
           Record CompartmentReturn_Pre (tid: nat) (st: ThreadState) : Prop :=
           { CRetReturn_PCCAddr: pcc st = CompartmentCallPCC
-          ; CRetReturn_TrustedStack: ValidTrustedStack (sts st).(thread_trustedStack)
+          ; CRetReturn_TrustedStack: ValidTrustedStack config (sts st).(thread_trustedStack)
           ; CRetReturn_Invariant: CompartmentCall_Invariant tid st st
           }.
 
           Record CompartmentReturn_Post (tid: nat) (st_init: ThreadState) (st: ThreadState) : Prop :=
           { CRetPost_Mode: ~(InSystemMode st)
           ; CRetPost_Cases: Post_UnwindStackReturnOk tid st_init st \/
-                              ThreadDead st
+                            ThreadDead st
           ; CRetPost_OnlyStackChanged: NonStackMemPreserved config tid (mem st_init) (mem st)
           }.
 
@@ -1583,26 +1585,7 @@ Module SwitcherProperty.
          
         End CompartmentReturn.
       
-      (* (* We want to define the behavior of the switcher as a function *)
-      (*    of thread-local state (register file, CSP-region of memory, *)
-      (*    system thread state) + read-only switcher state. We want to *)
-      (*    guarantee disjointness of other threads updates from *)
-      (*    thread-local memory regions. *)
-
-      (*    Then if we jump to the switcher's exception handler: *)
-      (*    - For some sequence of thread steps, P UNTIL Q *)
-      (*      - Q (Post): returns to usermode /\ R holds *)
-      (*      - P (Invariant): - it should act as a function of thread-local + read-only switcher state *)
-      (*           - not usermode  *)
-      (*      - R: post condition of exception handler, in terms of initial state *)
-      (*        - A good exception handler was found and we jumped to it *)
-      (*    - No guarantee of availability unless we add EVENTUALLY Q *)
-      (*  *) *)
-
-      (* (* TODO: fetchAddrs *) *)
-     
-   
-      End WithSwitcherParams.
+     End WithSwitcherParams.
     End WithConfig.
   End WithContext.
 End SwitcherProperty.

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -165,9 +165,24 @@ Section Machine.
          capKeepCanBeStored := c.(capKeepCanBeStored);
          capCursor := cursor
       |}.
+    Definition updateCapAddrs (c: Cap) (update: list Addr -> list Addr) : Cap :=
+      {| capSealed := c.(capSealed);
+         capPerms := c.(capPerms);
+         capCanStore := c.(capCanStore);
+         capCanBeStored := c.(capCanBeStored);
+         capSealingKeys := c.(capSealingKeys);
+         capUnsealingKeys := c.(capUnsealingKeys);
+         capAddrs := update c.(capAddrs);
+         capKeepPerms := c.(capKeepPerms);
+         capKeepCanStore := c.(capKeepCanStore);
+         capKeepCanBeStored := c.(capKeepCanBeStored);
+         capCursor := c.(capCursor) 
+      |}.
+
 
     Definition updateCapCursor (c: Cap) (fn: Addr -> Addr) : Cap :=
       setCapCursor c (fn c.(capCursor)).
+
 
     Definition isSentry (c: Cap) :=
       match c.(capSealed) with

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -527,7 +527,7 @@ Section Machine.
               e1 = e2
           | _, _ => False
           end.
-
+      (* TODO: PCC unsealed? *)
       Definition WfCallSentryInst (src: RegIdx) (optLink: option RegIdx):= forall rf pcc ints mem,
           ValidRf rf ->
           src < ISA_NREGS /\
@@ -537,7 +537,6 @@ Section Machine.
           | Ok (pcc', rf', ints') =>
             let caps := pcc :: capsOfRf rf in
             In Perm.Exec pcc.(capPerms) /\
-            isSealed pcc = false /\
             (exists src_cap,
                nth_error rf src = Some (inl src_cap) /\
                In Perm.Exec src_cap.(capPerms) /\
@@ -690,10 +689,13 @@ Section Machine.
           end.
 
         Definition fetchAddrsInBounds := Subset (fetchAddrs mem pcc.(capCursor)) pcc.(capAddrs)
-                                         /\ In pcc.(capCursor) pcc.(capAddrs).
+                                         /\ In pcc.(capCursor) pcc.(capAddrs)
+                                         /\ isSealed pcc = false
+                                         /\ In Perm.Exec pcc.(capPerms).                                                            
+
 
         Inductive ThreadStep : ((UserContext * SystemContext) * SameThreadEvent) -> Prop :=
-        | GoodUserThreadStep (inBounds: fetchAddrsInBounds) : ThreadStep threadStepFunction
+        | GoodThreadStep (inBounds: fetchAddrsInBounds) : ThreadStep threadStepFunction
         | BadUserFetch (notInBounds: ~ fetchAddrsInBounds) : ThreadStep (exceptionState pccNotInBounds).
       End WithContext.
 

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -175,6 +175,15 @@ Section Machine.
       | _ => false
       end.
 
+    Definition isForwardSentry (c: Cap) :=
+      match c.(capSealed) with
+      | Some (inl CallEnableInterrupt) => true 
+      | Some (inl CallDisableInterrupt) => true
+      | Some (inl CallInheritInterrupt) => true
+      | _ => false
+      end.
+
+
     Definition isSealedDataCap (c: Cap) :=
       match c.(capSealed) with
       | Some (inr _) => true

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -21,9 +21,14 @@ Module Perm.
   Scheme Equality for t.
 End Perm.
 
+Class MachineTypeParams := {
+    Byte : Type;
+    Key : Type
+}.
+
 Section Machine.
   Context [ISA: ISA_params].
-  Context {Byte Key: Type}.
+  Context {machineTypeParams: MachineTypeParams}.
   Definition Addr := nat.
   Definition CapAddr := nat.
   Definition toCapAddr (a: Addr): CapAddr := Nat.shiftr a ISA_LG_CAPSIZE_BYTES.
@@ -747,6 +752,10 @@ Module CHERIoTValidation.
   | Executable (GL: bool) (SR: bool) (LM: bool) (LG: bool) (* Implicit: EX, LD, MC *)
   | Sealing (GL: bool) (U0: bool) (SE: bool) (US: bool) (* Implicit: None *).
 
+  Instance machineTypeParams : MachineTypeParams :=
+    { Byte := N;
+      Key := N
+    }.
   Record cheriot_cap :=
   { reserved: bool;
     permissions: CompressedPerm;
@@ -862,7 +871,7 @@ Module CHERIoTValidation.
         |}
     end.
 
-  Definition mk_abstract_cap (c: cheriot_cap) : @Cap N :=
+  Definition mk_abstract_cap (c: cheriot_cap) : Cap :=
     let d := decompress_perm c.(permissions) in
     {|capSealed := if d.(EX)
                    then match c.(otype) with

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -786,7 +786,7 @@ Module CHERIoTValidation.
 
   Record Perm :=
     {
-      EX : bool; (* PERMIT_EXECuTE *)
+      EX : bool; (* PERMIT_EXECUTE *)
       GL : bool; (* GLOBAL *)
       LD : bool; (* PERMIT_LOAD *)
       SD : bool; (* PERMIT_STORE *)

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -130,6 +130,11 @@ Section Machine.
   Definition writeBytes (mem: FullMemory) := writeMemBytes (fst mem).
   Definition writeTag (mem: FullMemory) := writeTagTag (snd mem).
   Definition writeCap (mem: FullMemory) := writeMemTagCap (fst mem) (snd mem).
+  Definition writeCapOrBytes (mem: FullMemory) (a: Addr) (v: CapOrBytes) : FullMemory :=
+    match v with
+    | inl cap => writeCap mem (toCapAddr a) cap
+    | inr bytes => (writeBytes mem a bytes, snd mem)
+    end.    
 
   Definition ExnInfo := Bytes.
 

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -418,7 +418,7 @@ Section Machine.
     | ThreadDead.
 
     (* SystemThreadState is a first class entity like TrustedStack.
-      In CHERIoT, only MEPCC is a first class entity; the rest are objects in memory *)
+      In CHERIoT, only MEPCC and MTCC are first class entities; the rest are objects in memory *)
     Record SystemThreadState :=
       { thread_mepcc: MEPCC;
         thread_mtcc:  MTCC;
@@ -585,7 +585,6 @@ Section Machine.
               e1 = e2
           | _, _ => False
           end.
-      (* TODO: PCC unsealed? *)
       Definition WfCallSentryInst (src: RegIdx) (optLink: option RegIdx):= forall rf pcc ints mem,
           ValidRf rf ->
           src < ISA_NREGS /\

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -161,6 +161,9 @@ Section Machine.
          capCursor := cursor
       |}.
 
+    Definition updateCapCursor (c: Cap) (fn: Addr -> Addr) : Cap :=
+      setCapCursor c (fn c.(capCursor)).
+
     Definition isSentry (c: Cap) :=
       match c.(capSealed) with
       | Some (inl _) => true

--- a/src/Spec.v
+++ b/src/Spec.v
@@ -147,6 +147,20 @@ Section Machine.
          capKeepCanBeStored := c.(capKeepCanBeStored);
          capCursor := c.(capCursor)
       |}.
+    Definition setCapCursor (c: Cap) (cursor: Addr) : Cap :=
+      {| capSealed := c.(capSealed);
+         capPerms := c.(capPerms);
+         capCanStore := c.(capCanStore);
+         capCanBeStored := c.(capCanBeStored);
+         capSealingKeys := c.(capSealingKeys);
+         capUnsealingKeys := c.(capUnsealingKeys);
+         capAddrs := c.(capAddrs);
+         capKeepPerms := c.(capKeepPerms);
+         capKeepCanStore := c.(capKeepCanStore);
+         capKeepCanBeStored := c.(capKeepCanBeStored);
+         capCursor := cursor
+      |}.
+
     Definition isSentry (c: Cap) :=
       match c.(capSealed) with
       | Some (inl _) => true

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -701,7 +701,8 @@ Section WithContext.
         [ clear hwf_user; rename i into hmode| clear hwf_sys].
       - specialize hwf_sys with (1 := hmode) (2 := hpre) (mem := mem)
                                 (mepcc := thread_mepcc sysSt) (exnInfo := thread_exceptionInfo sysSt)
-                                (ts := thread_trustedStack sysSt) (ints := istatus).
+                                (ts := thread_trustedStack sysSt) (ints := istatus)
+                                (stat := thread_alive sysSt).
         setoid_rewrite hinst in hwf_sys. destruct_products. auto.
       - cbv[capsOfUserTS capsOfSystemTS]. destruct_products.
         specialize hwf_userl with (1 := hpre) (pcc := thread_pcc userSt) (mem := mem).

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -700,7 +700,9 @@ Section WithContext.
       destruct (in_dec Perm.t_eq_dec Perm.System (capPerms (thread_pcc userSt)));
         [ clear hwf_user; rename i into hmode| clear hwf_sys].
       - specialize hwf_sys with (1 := hmode) (2 := hpre) (mem := mem)
-                                (mepcc := thread_mepcc sysSt) (exnInfo := thread_exceptionInfo sysSt)
+                                (mepcc := thread_mepcc sysSt)
+                                (mtcc := thread_mtcc sysSt)
+                                (exnInfo := thread_exceptionInfo sysSt)
                                 (ts := thread_trustedStack sysSt) (ints := istatus)
                                 (stat := thread_alive sysSt).
         setoid_rewrite hinst in hwf_sys. destruct_products. auto.

--- a/src/SpecLemmas.v
+++ b/src/SpecLemmas.v
@@ -11,16 +11,16 @@ Set Nested Proofs Allowed.
 
 Section WithContext.
   Context [ISA: ISA_params].
-  Context {Byte Key: Type}.
-  Context {capEncodeDecode: @CapEncodeDecode Byte Key}.
-  Notation FullMemory := (@FullMemory Byte).
-  Notation Cap := (@Cap Key).
-  Notation CapOrBytes := (@CapOrBytes Byte Key).
-  Notation Machine := (@Machine Byte Key).
-  Notation AddrOffset := nat (only parsing).
-  Notation PCC := Cap (only parsing).
-  Notation RegisterFile := (@RegisterFile Byte Key).
-  Notation Thread := (@Thread Byte Key).
+  Context {machineTypeParams: MachineTypeParams}.
+  Context {capEncodeDecode: @CapEncodeDecode machineTypeParams}.
+  (* Notation FullMemory := (@FullMemory Byte). *)
+  (* Notation Cap := (@Cap Key). *)
+  (* Notation CapOrBytes := (@CapOrBytes Byte Key). *)
+  (* Notation Machine := (@Machine Byte Key). *)
+  (* Notation AddrOffset := nat (only parsing). *)
+  (* Notation PCC := Cap (only parsing). *)
+  (* Notation RegisterFile := (@RegisterFile Byte Key). *)
+  (* Notation Thread := (@Thread Byte Key). *)
 
   Section ISA_params.
     Lemma ISA_CAPSIZE_BYTES_NONZERO:
@@ -671,7 +671,7 @@ Section WithContext.
   Section WFInstructionLemmas.
     Lemma ValidRfUpdate:
       forall rf rf' v idx,
-        @ValidRf ISA Byte Key rf ->
+        ValidRf rf ->
         (forall n, n <> idx -> nth_error rf' n = nth_error rf n) ->
         idx < length rf ->
         nth_error rf' idx = Some v ->
@@ -737,8 +737,8 @@ Section WithContext.
 
   Section Step.
     Context {fetchAddrs: FullMemory -> Addr -> list Addr}.
-    Context {decode: list Byte -> @Inst _ _ _ capEncodeDecode}.
-    Context {pccNotInBounds : @EXNInfo Byte}.
+    Context {decode: list Byte -> @Inst _ _ capEncodeDecode}.
+    Context {pccNotInBounds : EXNInfo}.
     Notation MachineStep := (MachineStep fetchAddrs decode pccNotInBounds).
     Notation SameThreadStep := (SameThreadStep fetchAddrs decode pccNotInBounds).
     Notation ThreadStep := (ThreadStep fetchAddrs decode pccNotInBounds).

--- a/src/Utils.v
+++ b/src/Utils.v
@@ -14,6 +14,24 @@ Module Combinators.
         (Establish: invariant initial)
         (Preserve: forall s t, invariant s -> step s t -> invariant t)
         (Use: forall s, invariant s -> P s).
+
+    (* P until Q *)
+    Inductive untilAndThen (P: State -> Prop) (Q: State -> Prop) : Prop :=
+    | until_done:
+      Q initial ->
+      until P Q initial
+    | until_step:
+      P initial ->
+      (forall mid, step initial mid -> until P Q mid) ->
+      until P Q initial.
+
+    (* Inductive eventually(P: State -> Prop)(initial: State): Prop := *)
+    (* | eventually_done: *)
+    (*       P initial -> *)
+    (*       eventually P initial *)
+    (* | eventually_step: *)
+    (*       (forall mid, step initial mid -> eventually P mid) -> *)
+    (*       eventually P initial. *)
   End __.
 End Combinators.
 

--- a/src/Utils.v
+++ b/src/Utils.v
@@ -16,7 +16,7 @@ Module Combinators.
         (Use: forall s, invariant s -> P s).
 
     (* P until Q *)
-    Inductive untilAndThen (P: State -> Prop) (Q: State -> Prop) : Prop :=
+    Inductive until (P: State -> Prop) (Q: State -> Prop) (initial: State) : Prop :=
     | until_done:
       Q initial ->
       until P Q initial


### PR DESCRIPTION
This is a first pass at specifying the functional and security guarantees of the [switcher](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/core/switcher/entry.S), focusing on the compartment call/return and exception entry/return paths. The switcher is specified in terms of how it updates the registers and memory as a function of the state at time of entry into the switcher. We want to enable interrupts where possible, so the switcher should be correct even when other threads run concurrently. 

Notably, we enforce that the switcher operates only on read-only memory, thread-local stack, and the register file. This ensures that the switcher behaves as if it were atomic, with simple postconditions that can be stated in terms of the initial state. (Note that this property does not currently hold of the switcher, which can modify globals on the exception entry/return paths). 

Additions:
- Adds export table entries, export table addresses, and sealing capabilities to the initial configuration.
- Define a switcher compartment, along with its entry points and sealing key, in the initial configuration.
- Add initial conditions pertaining to read-only memory, stack-local memory, and sealing keys. State global invariants about read-only memory. 
- Add a notion of dead (corresponding to threads that have exited) or alive threads. Only alive threads can take steps.
- Add postconditions for the switcher.

Bug fixes:
- Jump to MTCC after an exception, instead of MEPCC 